### PR TITLE
TS-50: Ensure non working project is shown on bank holidays

### DIFF
--- a/packages/backhouse/src/integrations/google-sheets/transformer/calculate-overtime.ts
+++ b/packages/backhouse/src/integrations/google-sheets/transformer/calculate-overtime.ts
@@ -1,0 +1,71 @@
+import { NON_WORKING_PROJECT_NAME, TOIL_TASK_NAME } from '@timesheeter/web';
+import { type GroupedEntry } from './lib';
+
+const WORK_DAY_LENGTH_HOURS = 8;
+
+/**  Need to calculate overtime, overtime is applied to each entry based on the hours already worked in that day, ie later entries might have overtime applied to them, earlier ones won't. There are 8 hours */
+export const calculateOvertime = (
+  groupedEntries: Omit<GroupedEntry, 'overtime'>[],
+  isWorkDay: boolean
+): GroupedEntry[] => {
+  // If not a workday, then overtime is applied to all entries except non working entries
+  if (!isWorkDay) {
+    return calculateOvertimeNonWorkDay(groupedEntries);
+  }
+
+  let timeWorked = 0;
+
+  return groupedEntries.map((groupedEntry) => {
+    // If task name is TOIL_TASK_NAME then subtract overtime as time off in lieu
+    if (
+      groupedEntry.task.name.toUpperCase() === TOIL_TASK_NAME &&
+      groupedEntry.task.project.name === NON_WORKING_PROJECT_NAME
+    ) {
+      return {
+        ...groupedEntry,
+        overtime: -groupedEntry.time,
+      };
+    }
+
+    // If task name is NON_WORKING_PROJECT_NAME then don't apply overtime
+    // Must also not be TOIL_TASK_NAME as that is a special case but we have already
+    // handled that above
+    if (groupedEntry.task.project.name === NON_WORKING_PROJECT_NAME) {
+      return {
+        ...groupedEntry,
+        overtime: 0,
+      };
+    }
+
+    let newGroupedEntry: GroupedEntry | null = null;
+
+    if (timeWorked > WORK_DAY_LENGTH_HOURS) {
+      newGroupedEntry = {
+        ...groupedEntry,
+        overtime: groupedEntry.time,
+      };
+    } else if (timeWorked + groupedEntry.time < WORK_DAY_LENGTH_HOURS) {
+      newGroupedEntry = {
+        ...groupedEntry,
+        overtime: 0,
+      };
+    } else {
+      // Only some of the time is overtime
+      newGroupedEntry = {
+        ...groupedEntry,
+        overtime: timeWorked + groupedEntry.time - WORK_DAY_LENGTH_HOURS,
+      };
+    }
+
+    timeWorked += groupedEntry.time;
+
+    return newGroupedEntry;
+  });
+};
+
+const calculateOvertimeNonWorkDay = (groupedEntries: Omit<GroupedEntry, 'overtime'>[]): GroupedEntry[] =>
+  groupedEntries.map((groupedEntry) => ({
+    ...groupedEntry,
+    // Don't apply overtime to non working entries
+    overtime: groupedEntry.projectName === NON_WORKING_PROJECT_NAME ? 0 : groupedEntry.time,
+  }));

--- a/packages/backhouse/src/integrations/google-sheets/transformer/index.ts
+++ b/packages/backhouse/src/integrations/google-sheets/transformer/index.ts
@@ -1,6 +1,14 @@
-import { type DatabaseEntries } from './database-entries';
-import { getBankHolidayDates } from './bank-holidays';
-import { NON_WORKING_PROJECT_NAME, TOIL_TASK_NAME } from '@timesheeter/web';
+import { type DatabaseEntries } from '../database-entries';
+import { getBankHolidayDates } from '../bank-holidays';
+import { calculateOvertime } from './calculate-overtime';
+import {
+  formatOutputDate,
+  formatTaskDetails,
+  formatTime,
+  removeDetailDuplicates,
+  type GroupedEntry,
+  calculateIsWorkDay,
+} from './lib';
 
 export type TransformedData = {
   date: Date;
@@ -103,14 +111,6 @@ const formatTimesheetEntryCells = (
   });
 };
 
-type GroupedEntry = {
-  task: DatabaseEntries['timesheetEntries'][number]['task'];
-  projectName: string;
-  time: number;
-  details: string;
-  overtime: number;
-};
-
 const groupEntriesToTasks = (
   timesheetEntriesDate: DatabaseEntries['timesheetEntries'],
   isWorkDay: boolean
@@ -144,119 +144,4 @@ const groupEntriesToTasks = (
     }));
 
   return calculateOvertime(groupedEntries, isWorkDay).filter((timedGroupedEntry) => timedGroupedEntry.time >= 0.25);
-};
-
-const OVERTIME_HOURS = 8;
-
-/**  Need to calculate overtime, overtime is applied to each entry based on the hours already worked in that day, ie later entries might have overtime applied to them, earlier ones won't. There are 8 hours */
-const calculateOvertime = (groupedEntries: Omit<GroupedEntry, 'overtime'>[], isWorkDay: boolean): GroupedEntry[] => {
-  // If not a workday, then overtime is applied to all entries
-  if (!isWorkDay) {
-    // Filter out non working entries as we don't want to include them if not a work day
-    const entriesWorking = groupedEntries.filter(
-      (groupedEntry) => groupedEntry.task.project.name !== NON_WORKING_PROJECT_NAME
-    );
-
-    return entriesWorking.map((groupedEntry) => ({
-      ...groupedEntry,
-      overtime: groupedEntry.time,
-    }));
-  }
-
-  let timeWorked = 0;
-
-  return groupedEntries.map((groupedEntry) => {
-    // If task name is TOIL_TASK_NAME then subtract overtime as time off in lieu
-    if (
-      groupedEntry.task.name.toUpperCase() === TOIL_TASK_NAME &&
-      groupedEntry.task.project.name === NON_WORKING_PROJECT_NAME
-    ) {
-      return {
-        ...groupedEntry,
-        overtime: -groupedEntry.time,
-      };
-    }
-
-    // If task name is NON_WORKING_PROJECT_NAME then don't apply overtime
-    // Must also not be TOIL_TASK_NAME as that is a special case but we have already
-    // handled that above
-    if (groupedEntry.task.project.name === NON_WORKING_PROJECT_NAME) {
-      return {
-        ...groupedEntry,
-        overtime: 0,
-      };
-    }
-
-    let newGroupedEntry: GroupedEntry | null = null;
-
-    if (timeWorked > OVERTIME_HOURS) {
-      newGroupedEntry = {
-        ...groupedEntry,
-        overtime: groupedEntry.time,
-      };
-    } else if (timeWorked + groupedEntry.time < OVERTIME_HOURS) {
-      newGroupedEntry = {
-        ...groupedEntry,
-        overtime: 0,
-      };
-    } else {
-      // Only some of the time is overtime
-      newGroupedEntry = {
-        ...groupedEntry,
-        overtime: timeWorked + groupedEntry.time - OVERTIME_HOURS,
-      };
-    }
-
-    timeWorked += groupedEntry.time;
-
-    return newGroupedEntry;
-  });
-};
-
-const calculateIsWorkDay = (bankHolidays: Date[], date: Date): boolean => {
-  // If weekend then not a work day, needs to not be utc
-  const day = date.getUTCDay();
-
-  if (day === 0 || day === 6) {
-    return false;
-  }
-
-  // If bank holiday then not a work day
-  if (bankHolidays.some((bankHoliday) => bankHoliday.getTime() === date.getTime())) {
-    return false;
-  }
-
-  return true;
-};
-
-/** Formats milliseconds to quarter hourly eg 0.25 hours or 1.25 hours */
-const formatTime = (durationMillis: number): number => {
-  const durationHours = durationMillis / 3600000;
-
-  return Number((Math.round(durationHours * 4) / 4).toFixed(2));
-};
-
-const formatOutputDate = (date: Date) =>
-  date.toLocaleDateString('en-GB', { day: 'numeric', month: 'numeric', year: 'numeric' });
-
-const removeDetailDuplicates = (input: string) => {
-  const items = input
-    .split(',')
-    .map((item) => item.trim())
-    .filter((item) => item !== '');
-
-  // We reverse the array as we want the oldest description to be first so there
-  // is a chronological order to the descriptions
-  const uniqueItems = Array.from(new Set(items)).reverse();
-  return uniqueItems.join(', ');
-};
-
-const formatTaskDetails = (task: DatabaseEntries['timesheetEntries'][number]['task']) => {
-  const taskNumber = task.ticketForTask ? `${task.ticketForTask.taskPrefix.prefix}-${task.ticketForTask.number}` : null;
-
-  if (taskNumber) {
-    return task.name ? `${taskNumber}: ${task.name}` : taskNumber;
-  }
-
-  return task.name;
 };

--- a/packages/backhouse/src/integrations/google-sheets/transformer/lib.ts
+++ b/packages/backhouse/src/integrations/google-sheets/transformer/lib.ts
@@ -1,0 +1,55 @@
+import { type DatabaseEntries } from '../database-entries';
+
+export type GroupedEntry = {
+  task: DatabaseEntries['timesheetEntries'][number]['task'];
+  projectName: string;
+  time: number;
+  details: string;
+  overtime: number;
+};
+
+export const formatTaskDetails = (task: DatabaseEntries['timesheetEntries'][number]['task']) => {
+  const taskNumber = task.ticketForTask ? `${task.ticketForTask.taskPrefix.prefix}-${task.ticketForTask.number}` : null;
+
+  if (taskNumber) {
+    return task.name ? `${taskNumber}: ${task.name}` : taskNumber;
+  }
+
+  return task.name;
+};
+
+export const formatOutputDate = (date: Date) =>
+  date.toLocaleDateString('en-GB', { day: 'numeric', month: 'numeric', year: 'numeric' });
+
+/** Formats milliseconds to quarter hourly eg 0.25 hours or 1.25 hours */
+export const formatTime = (durationMillis: number): number => {
+  const durationHours = durationMillis / 3600000;
+
+  return Number((Math.round(durationHours * 4) / 4).toFixed(2));
+};
+
+export const removeDetailDuplicates = (input: string) => {
+  const items = input
+    .split(',')
+    .map((item) => item.trim())
+    .filter((item) => item !== '');
+
+  const uniqueItems = Array.from(new Set(items));
+
+  return uniqueItems.join(', ');
+};
+
+export const calculateIsWorkDay = (bankHolidays: Date[], date: Date): boolean => {
+  // If weekend then not a work day
+  const day = date.getUTCDay();
+  if (day === 0 || day === 6) {
+    return false;
+  }
+
+  // If bank holiday then not a work day
+  if (bankHolidays.some((bankHoliday) => bankHoliday.getTime() === date.getTime())) {
+    return false;
+  }
+
+  return true;
+};


### PR DESCRIPTION
Go to https://staging.bluetel.timesheeter.pro/ or run local setup

Create the project named "Non Working" it needs to be exact, add some task called holiday add a task named "TOIL" 

Create a load of fake entries on a weekday bank holiday e.g. christmas day 2023 as was a monday, add Holiday to it and create a fake work entry under another project.

You should get something like this, no overtime for non working project at all, and overtime for all other work entries
![image](https://github.com/bluetel/timesheeter/assets/13287945/fcfb4ba1-eed5-4779-9a8c-5032abdfaea9)
