### PR TITLE
Fix issues with rate limits and deleting sheets

### DIFF
--- a/packages/backhouse/src/integrations/google-sheets/index.ts
+++ b/packages/backhouse/src/integrations/google-sheets/index.ts
@@ -98,11 +98,6 @@ const outputToTimesheet = async ({
     return
   }
 
-  // We can't process entries before when we first started recording them
-  if (databaseEntriesBasedStartDate > firstDayToProcess) {
-    firstDayToProcess = databaseEntriesBasedStartDate;
-  }
-
   const transformedData = await getTransformedSheetData({
     databaseEntries,
     firstDayToProcess,


### PR DESCRIPTION
- We don't remove sheets anymore, we don't need to
- Deleting more sheets means they can backfill more than 2 months
- Sync from current month + 1 month (entries are overwritten)
- Add a sleep between each sync for 10 seconds to try to stay in the lambda execution time.